### PR TITLE
copy array to have it's own data if it doesn't already with upload vi…

### DIFF
--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -625,6 +625,7 @@ class ArrayInterface(BasicInterface):
             if isinstance(v, dict):
                 _ = self.dict2cloud(name, v, acl=acl, **metadata)
             elif isinstance(v, np.ndarray):
+                v = v if v.flags.owndata else np.array(v)
                 _ = self.upload_raw_array(name, v, acl=acl, **metadata)
             else: # try converting to array
                 _ = self.upload_raw_array(name, np.asarray(v), acl=acl)


### PR DESCRIPTION
…a dict2cloud
When uploading a dict containing an array `arr` with `arr.flags.owndata=False` (like if `arr` is a slice of a larger array) I got an error

> ---------------------------------------------------------------------------
> AttributeError                            Traceback (most recent call last)
> <ipython-input-2-0dc4155ee2fa> in <module>()
> ----> 1 cci.dict2cloud('tmp2', {'x':np.random.randn(10,10)[::3,::2]})
> 
> /auto/k1/robertg/code/cottoncandy/cottoncandy/utils.pyc in iremove_root(self, object_name, *args, **kwargs)
>     128         elif object_name[0] == SEPARATOR:
>     129             object_name = object_name[1:]
> --> 130         return input_function(self, object_name, *args, **kwargs)
>     131     return iremove_root
>     132 
> 
> /auto/k1/robertg/code/cottoncandy/cottoncandy/interfaces.py in dict2cloud(self, object_name, array_dict, acl, verbose, **metadata)
>     618             elif isinstance(v, np.ndarray):
>     619 #                v = v if v.flags.owndata else np.array(v)
> --> 620                 _ = self.upload_raw_array(name, v, acl=acl, **metadata)
>     621             else: # try converting to array
>     622                 _ = self.upload_raw_array(name, np.asarray(v), acl=acl)
> 
> /auto/k1/robertg/code/cottoncandy/cottoncandy/utils.pyc in iremove_root(self, object_name, *args, **kwargs)
>     128         elif object_name[0] == SEPARATOR:
>     129             object_name = object_name[1:]
> --> 130         return input_function(self, object_name, *args, **kwargs)
>     131     return iremove_root
>     132 
> 
> /auto/k1/robertg/code/cottoncandy/cottoncandy/interfaces.py in upload_raw_array(self, object_name, array, gzip, acl, **metadata)
>     543             zipdata = StringIO()
>     544             gz = GzipFile(mode='wb', fileobj=zipdata)
> --> 545             gz.write(array.data)
>     546             gz.close()
>     547             zipdata.seek(0)
> 
> AttributeError: cannot get single-segment buffer for discontiguous array

This fix eliminated that error, and I tested that the data is reliably saved to the destination.