### PR TITLE
Python 3 compatibility

### DIFF
--- a/cottoncandy/browser.py
+++ b/cottoncandy/browser.py
@@ -2,23 +2,23 @@
 '''
 import os
 
-from utils import (clean_object_name,
-                   has_start_digit,
-                   has_magic,
-                   has_real_magic,
-                   has_trivial_magic,
-                   remove_trivial_magic,
-                   remove_root,
-                   mk_aws_path,
-                   objects2names,
-                   unquote_names,
-                   print_objects,
-                   get_fileobject_size,
-                   get_object_size,
-                   read_buffered,
-                   GzipInputStream,
-                   generate_ndarray_chunks,
-                   )
+from cottoncandy.utils import (clean_object_name,
+                               has_start_digit,
+                               has_magic,
+                               has_real_magic,
+                               has_trivial_magic,
+                               remove_trivial_magic,
+                               remove_root,
+                               mk_aws_path,
+                               objects2names,
+                               unquote_names,
+                               print_objects,
+                               get_fileobject_size,
+                               get_object_size,
+                               read_buffered,
+                               GzipInputStream,
+                               generate_ndarray_chunks,
+                               )
 
 
 

--- a/cottoncandy/utils.py
+++ b/cottoncandy/utils.py
@@ -157,7 +157,7 @@ def print_objects(object_list):
         padding = '{0: <%i} {1} {2}M'%(min(maxlen+3, 70))
         sizes = [round(t.meta.data['Size']/2.**20,1) for t in object_list]
         info = [padding.format(name[-100:],date,size) for name,date,size in zip(object_names, dates, sizes)]
-        print '\n'.join(info)
+        print('\n'.join(info))
 
 
 # object naming convention


### PR DESCRIPTION
I am not sure whether this covers all use-cases, but it installs/imports cleanly on Python 3.5 and I tried at least the following use-case: 

    i = cottoncandy.get_interface(ACCESS_KEY="XXXXXXXXXX", SECRET_KEY="XXXXXXXXXXX", endpoint_url="https://s3.amazonaws.com", bucket_name="my-bucket")

    o = i.download_object("subject_name/volume_with_data.nii.gz")

    with open('out.nii.gz','wb') as f:
         f.write(o)

which produced a legit nifti file with the data properly saved in it. Anything else I should try? Are the doc examples supposed to run using something like `nosetests --with-doctest`? 

