### PR TITLE
Python3compatibility

### DIFF
--- a/cottoncandy/gdriveclient.py
+++ b/cottoncandy/gdriveclient.py
@@ -3,6 +3,7 @@ from pydrive.auth import GoogleAuth
 from pydrive.drive import GoogleDrive
 from pydrive.files import GoogleDriveFile, FileNotUploadedError, ApiRequestError
 from .backend import CCBackEnd, FileNotFoundError, CloudStream
+import six
 import sys
 import re
 
@@ -428,7 +429,7 @@ class GDriveClient(CCBackEnd):
         if cloud_name is None:
             cloud_name = file_name
 
-        if type(file_name) != str:
+        if not isinstance(file_name, six.string_types): #type(file_name) != str:
             # assume this is a file_name-like object
             self.upload_stream(file_name, cloud_name)
 

--- a/cottoncandy/gdriveclient.py
+++ b/cottoncandy/gdriveclient.py
@@ -429,7 +429,7 @@ class GDriveClient(CCBackEnd):
         if cloud_name is None:
             cloud_name = file_name
 
-        if not isinstance(file_name, six.string_types): #type(file_name) != str:
+        if not isinstance(file_name, six.string_types):
             # assume this is a file_name-like object
             self.upload_stream(file_name, cloud_name)
 

--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -1,4 +1,5 @@
 import json
+import six
 
 try:
     import cPickle as pickle
@@ -413,7 +414,7 @@ class BasicInterface(InterfaceObject):
         metadata : dict, optional
         """
         json_data = json.dumps(ddict)
-        return self.upload_object(object_name, StringIO(json_data), acl, **metadata)
+        return self.upload_object(object_name, StringIO(json_data.encode()), acl, **metadata)
 
     @clean_object_name
     def download_json(self, object_name):
@@ -562,6 +563,8 @@ class ArrayInterface(BasicInterface):
                    'before saving (will use extra memory)')
             array = np.array(array, order = order)
 
+
+
         meta = dict(dtype = array.dtype.str,
                     shape = ','.join(map(str, array.shape)),
                     gzip = str(gzip),
@@ -577,6 +580,12 @@ class ArrayInterface(BasicInterface):
         meta.update(metadata)
 
         if gzip:
+            if six.PY3:
+                # eventually, array.data below should be changed to np.getbuffer(array)
+                # (not yet working in python3 numpy)
+                if array.flags['F_CONTIGUOUS']:
+                    # F-contiguous arrays break gzip in python 3
+                    array = array.T
             zipdata = StringIO()
             gz = GzipFile(mode = 'wb', fileobj = zipdata)
             gz.write(array.data)
@@ -619,7 +628,7 @@ class ArrayInterface(BasicInterface):
         shape = map(int, shape.split(',')) if shape else ()
         dtype = np.dtype(arraystream.metadata['dtype'])
         order = arraystream.metadata.get('order', 'C')
-        array = np.empty(shape, dtype = dtype, order = order)
+        array = np.empty(tuple(shape), dtype = dtype, order = order)
 
         body = arraystream.content
         if 'gzip' in arraystream.metadata and arraystream.metadata['gzip'] == 'True':

--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -563,8 +563,6 @@ class ArrayInterface(BasicInterface):
                    'before saving (will use extra memory)')
             array = np.array(array, order = order)
 
-
-
         meta = dict(dtype = array.dtype.str,
                     shape = ','.join(map(str, array.shape)),
                     gzip = str(gzip),
@@ -580,12 +578,11 @@ class ArrayInterface(BasicInterface):
         meta.update(metadata)
 
         if gzip:
-            if six.PY3:
+            if six.PY3 and array.flags['F_CONTIGUOUS']:
                 # eventually, array.data below should be changed to np.getbuffer(array)
                 # (not yet working in python3 numpy)
-                if array.flags['F_CONTIGUOUS']:
-                    # F-contiguous arrays break gzip in python 3
-                    array = array.T
+                # F-contiguous arrays break gzip in python 3
+                array = array.T
             zipdata = StringIO()
             gz = GzipFile(mode = 'wb', fileobj = zipdata)
             gz.write(array.data)

--- a/cottoncandy/tests/test_roundtrip.py
+++ b/cottoncandy/tests/test_roundtrip.py
@@ -13,14 +13,14 @@ import cottoncandy as cc
 
 DATE = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
 
-prefix = 'testcc/%s/py%s'%(DATE, sys.version[:6])
+prefix = 'testcc/%s/py%s'%(DATE, sys.version[:sys.version.find(' ')])
 object_name = os.path.join(prefix, 'test')
 
 
 # login
 ##############################
 
-if 1:
+if False:
     # for travis testing on AWS.
     bucket_name = os.environ['DL_BUCKET_NAME']
     AK = os.environ['DL_ACCESS_KEY']
@@ -64,7 +64,7 @@ def content_generator():
                 if kind == 'raw':
                     yield data
                 elif kind == 'slice':
-                    yield data[data.shape[0]/2:]
+                    yield data[int(data.shape[0]/2):]
                 elif kind == 'nonco':
                     yield data[np.random.randint(0,data.shape[0],10)]
 
@@ -125,8 +125,8 @@ def test_upload_npy_upload():
         assert np.allclose(dat, content)
 
 def test_upload_raw_array():
-    for content in content_generator():
-        print(cci.upload_raw_array(object_name, content))
+    for i, content in enumerate(content_generator()):
+        print(i, cci.upload_raw_array(object_name, content))
         time.sleep(1.0)
         dat = cci.download_raw_array(object_name)
         assert np.allclose(dat, content)

--- a/cottoncandy/tests/test_roundtrip.py
+++ b/cottoncandy/tests/test_roundtrip.py
@@ -13,7 +13,7 @@ import cottoncandy as cc
 
 DATE = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
 
-prefix = 'testcc/%s/py%s'%(DATE, sys.version[:sys.version.find(' ')])
+prefix = 'testcc/%s/py%s'%(DATE, sys.version[:6])
 object_name = os.path.join(prefix, 'test')
 
 

--- a/cottoncandy/tests/test_roundtrip.py
+++ b/cottoncandy/tests/test_roundtrip.py
@@ -20,7 +20,7 @@ object_name = os.path.join(prefix, 'test')
 # login
 ##############################
 
-if False:
+if True:
     # for travis testing on AWS.
     bucket_name = os.environ['DL_BUCKET_NAME']
     AK = os.environ['DL_ACCESS_KEY']

--- a/cottoncandy/tests/test_roundtrip_big.py
+++ b/cottoncandy/tests/test_roundtrip_big.py
@@ -57,7 +57,7 @@ def content_generator():
     for kind in kinds:
         for order in orders:
             for dtype in types:
-                data = np.random.randn(1 + 200*(2**20)/8)
+                data = np.random.randn(int(1 + 200*(2**20)/8))
                 data = np.asarray(data, order=order).astype(dtype)
 
                 if kind == 'raw':

--- a/cottoncandy/utils.py
+++ b/cottoncandy/utils.py
@@ -431,19 +431,18 @@ def read_buffered(frm, to, buffersize=64):
             vw = to.T.view()
         else:
             vw = to.view()
-        vw.shape = (-1,) # Must be a ravel-able object
-        vw.dtype = np.dtype('uint8') # 256 values in each byte
+        vw.shape = (-1,)                # Must be a ravel-able object
+        vw.dtype = np.dtype('uint8')    # 256 values in each byte
 
     for ci in range(int(np.ceil(nbytes_total / float(buffersize)))):
         start = ci * buffersize
         end = min(nbytes_total, (ci + 1) * buffersize)
-        chunk = frm.read(end - start)
         if six.PY2:
-            to.data[start:end] = chunk
+            to.data[start:end] = frm.read(end - start)
         elif six.PY3:
-            vw.data[start:end] = chunk
+            vw.data[start:end] = frm.read(end - start)
         else:
-            raise("Unknown python version")
+            raise("Unknown python version") # not sure six will ever do anything here (6=2x3)
 
 class GzipInputStream(object):
     """Simple class that allow streaming reads from GZip files


### PR DESCRIPTION
A better fix for some of the issues addressed here would be to use np.getbuffer() to get bytestream representations of arrays, but that is not yet uniformly implemented in readily-accessible numpy versions. Should work as is w/ slightly hacky solutions. 