### PR TITLE
minor fix to make lsdir work in python3. turn generators into lists

### DIFF
--- a/cottoncandy/s3client.py
+++ b/cottoncandy/s3client.py
@@ -509,12 +509,12 @@ class S3Client(CCBackEnd):
         object_names = []
         if 'CommonPrefixes' in response:
             # we got common paths
-            object_list = [t.values() for t in response['CommonPrefixes']]
+            object_list = [list(t.values()) for t in response['CommonPrefixes']]
             object_names += reduce(lambda x, y: x + y, object_list)
         if 'Contents' in response:
             # we got objects on the leaf nodes
             object_names += unquote_names([t['Key'] for t in response['Contents']])
-        return map(os.path.normpath, object_names)
+        return [os.path.normpath(n) for n in object_names]
 
     def delete(self, object_name, recursive=False, delete=False):
         raise RuntimeError('Deleting on S3 backend is implemented by cottoncandy interface object')


### PR DESCRIPTION
Python 3 looooves generators. Everything is a generator. Nothing is a list. lsdir relies on `dict.values()` and `map` to return lists, but in python3 they are `dict_values` and `generator`. Force these things to be lists in python2 and 3.