### PR TITLE
numcodecs compression

### DIFF
--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -648,6 +648,13 @@ class ArrayInterface(BasicInterface):
         array = np.empty(tuple(shape), dtype = dtype, order = order)
 
         body = arraystream.content
+        # Backward compatibility
+        if 'gzip' in arraystream.metadata:
+            # Assume old file; over-write "compression" value
+            if arraystream.metadata['gzip']:
+                arraystream['compression'] = 'gzip'
+            else:
+                arraystream['compression'] = 'None'
         if 'compression' in arraystream.metadata and arraystream.metadata['compression'] != "None":
             if arraystream.metadata['compression'] == 'gzip':
                 # gzipped!

--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -605,9 +605,11 @@ class ArrayInterface(BasicInterface):
             filestream = zipdata
             data_nbytes = get_fileobject_size(filestream)
         elif hasattr(numcodecs, compression.lower()): # if the mentioned compression type is in numcodecs
-            data_nbytes = array.nbytes
+            orig_nbytes = get_fileobject_size(filestream)
             compressor = eval("numcodecs.{}.{}()".format(compression.lower(), compression)) #TODO: this errors if the compression name is not properly formatted. Please handle it
-            filestream = compressor.encode(array)
+            filestream = StringIO(compressor.encode(array))
+            data_nbytes = get_fileobject_size(filestream)
+            print('Compressed to %0.2f%% the size'%(data_nbytes / float(orig_nbytes) * 100))
         elif compression is None:
             data_nbytes = array.nbytes
             filestream = StringIO(array.data)

--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -606,12 +606,13 @@ class ArrayInterface(BasicInterface):
             data_nbytes = get_fileobject_size(filestream)
         elif hasattr(numcodecs, compression.lower()): # if the mentioned compression type is in numcodecs
             data_nbytes = array.nbytes
-            compressor = eval("numcodecs.{1}.{2}()".format(compression.lower(), compression)) #TODO: this errors if the compression name is not properly formatted. Please handle it
+            compressor = eval("numcodecs.{}.{}()".format(compression.lower(), compression)) #TODO: this errors if the compression name is not properly formatted. Please handle it
             filestream = compressor.encode(array)
-        else:
+        elif compression is None:
             data_nbytes = array.nbytes
             filestream = StringIO(array.data)
-
+        else:
+            raise ValueError("Unknown compression scheme: %s"%compression)
         response = self.upload_object(object_name, filestream, acl=acl, **meta)
         return response
 
@@ -650,7 +651,7 @@ class ArrayInterface(BasicInterface):
                 # gzipped!
                 datastream = GzipInputStream(body)
             else:
-                decompressor = eval("numcodecs.{1}.{2}()".format(arraystream.metadata['compression'].lower(), arraystream.metadata['compression']))
+                decompressor = eval("numcodecs.{}.{}()".format(arraystream.metadata['compression'].lower(), arraystream.metadata['compression']))
                 datastream = decompressor.decode(body)
         else:
             datastream = body

--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -677,13 +677,11 @@ class ArrayInterface(BasicInterface):
                 compr = arraystream.metadata['compression']
                 decompressor = getattr(importlib.import_module('numcodecs.{}'.format(compr.lower())), compr)()
                 # Can't decode stream; must read in file. Memory hungry?
-                bits_compr = body.read()
+                bits_compr = arraystream.content.read()
                 bits = decompressor.decode(bits_compr)
-                # Doesn't work directly...
-                # array.data = bits
-                # return array
-                # ... so: (This feels like it's missing the point, but works)
-                datastream = StringIO(bits)
+                array = np.frombuffer(bits, dtype=dtype)
+                array = array.reshape(shape)
+                return array
         else:
             datastream = body
 

--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -665,9 +665,9 @@ class ArrayInterface(BasicInterface):
         if 'gzip' in arraystream.metadata:
             # Assume old file; over-write "compression" value
             if arraystream.metadata['gzip']:
-                arraystream['compression'] = 'gzip'
+                arraystream.metadata['compression'] = 'gzip'
             else:
-                arraystream['compression'] = 'None'
+                arraystream.metadata['compression'] = 'None'
         if 'compression' in arraystream.metadata and arraystream.metadata['compression'] != "None":
             if arraystream.metadata['compression'] == 'gzip':
                 # gzipped!

--- a/cottoncandy/tests/test_roundtrip_big.py
+++ b/cottoncandy/tests/test_roundtrip_big.py
@@ -69,7 +69,7 @@ def content_generator():
 
 def test_upload_raw_array():
     for content in content_generator():
-        print(cci.upload_raw_array(object_name, content, gzip=False))
+        print(cci.upload_raw_array(object_name, content, compression=None))
         time.sleep(1.0)
         dat = cci.download_raw_array(object_name)
         assert np.allclose(dat, content)


### PR DESCRIPTION
Compression w/ numcodecs is working, tho may be unkind to memory. As far as I can tell, numcodecs does not support compression of filestreams, just whole buffers, so I think there may be copying of data in RAM. Code needs review by ppl better versed in streams & file-like objecst than me. This will only be an issue if the numcodecs compression is used; I would take it, even with a hit to RAM, probably, because compression is important for big files (still not tested in production). 

One keyword argument to upload_raw_array() has been changed: gzip=True is now compression='gzip', with other possibilities for compression. The code will still recognize and handle gzip=True with a deprecation warning. 

Some compression algorithms in numcodecs (Zlib, LZ4) still fail with large (> 2GB) arrays. BZ2 is very slow, but compresses more (by default); Zstd seems best for tradeoff of speed of encoding / decoding and compression rate. These algorithms take parameters to trade off btw compression speed and % compression, but there is currently no way to specify those for cottoncandy (each just goes with its defaults). This could be added in the future, but defaults seem OK.