### PR TITLE
dask api update

### DIFF
--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -891,7 +891,7 @@ class ArrayInterface(BasicInterface):
         from dask import array as da
 
         metadata = self.download_json(self.pathjoin(object_name, 'metadata.json'))
-        chunks = metadata['chunks']
+        chunks = list(map(tuple, metadata['chunks']))
         shape = metadata['shape']
         dtype = np.dtype(metadata['dtype'])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ wheel>=0.31.1
 numpy>=1.6.0
 scipy>=0.9.0
 boto3>=1.2.3
-dask==0.10.2
+dask[array]
 cloudpickle>=0.2.2
 toolz>=0.7.4
 pycrypto>=2.6.1


### PR DESCRIPTION
Updated `download_dask_array()` for latest dask API. 
Tested with `dask[array] == 2021.02.0`

@candytaco :  The CI is not working. Could I ask you to please run the tests for this branch?

closes #79 
