### PR TITLE
Replace PyCrypto with PyCryptodome

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See the [Google Drive setup instructions](https://github.com/gallantlab/cottonca
 
 ### Encryption
 
-`cottoncandy`provides a transparent encryption interface for AWS S3 and Google Drive. This requires the `pycrypto` package. 
+`cottoncandy`provides a transparent encryption interface for AWS S3 and Google Drive. This requires the `pycryptodome` package. 
 
 **WARNING**: Encryption is an advance feature. Make sure to create a backup of the encryption keys  (stored in `~/.config/cottoncandy/options.cfg`). If you lose your encryption keys you will not be able to recover your data!
 

--- a/cottoncandy/options.py
+++ b/cottoncandy/options.py
@@ -55,7 +55,7 @@ def generate_AES_key(bytes = 32):
         from Crypto import Random
         return Random.get_random_bytes(bytes)
     except ImportError:
-        print('PyCrypto not install. Reading from /dev/random instead')
+        print('PyCrypto/PyCryptoDome not installed. Reading from /dev/random instead')
         with open('/dev/random', 'r') as rand:
             return rand.read(bytes)
 

--- a/google_drive_setup_instructions.md
+++ b/google_drive_setup_instructions.md
@@ -1,7 +1,7 @@
 To set up Google Drive access, you need to jump through many hoops.
 
 #### Python dependencies
-You need to have `pydrive` and `pycrypto` installed.
+You need to have `pydrive` and `pycryptodome` installed.
 
 #### Google Drive API setup
 1. Go to https://console.developers.google.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.2.3, <=1.15
 dask[array]
 cloudpickle>=0.2.2
 toolz>=0.7.4
-pycrypto>=2.6.1
+pycryptodome>=2.6.1
 pydrive>=1.3.1
 numcodecs>=0.5.5
 six>=1.11.0

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def main(**kwargs):
           include_package_data=True,
           long_description=long_description,
           install_requires=['six', 'botocore', 'boto3', 'python-dateutil',
-                            'PyDrive', 'pycrypto'],
+                            'PyDrive', 'pycryptodome'],
           **kwargs)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #90 and allows installation for Python 3.11 and 3.12.

Not sure if any encryption-related functions are tested automatically.