### PR TITLE
Fix encryption for Python <= 3.7

### DIFF
--- a/cottoncandy/Encryption.py
+++ b/cottoncandy/Encryption.py
@@ -238,7 +238,7 @@ class AESEncryption(Encryption):
                         # pad the end chunk if necessary - AES needs things to be in 16-byte blocks
                         padSize = 16 - (len(this_chunk) + FILE_LENGTH_FIELD_SIZE) % 16
                         padding = ' ' * padSize
-                        this_chunk += padding
+                        this_chunk += padding.encode()
                         this_chunk += file_length_field  # record the actual file length so we can get ride of the padding on decryption
                         is_final_chunk = True
 
@@ -292,7 +292,7 @@ class AESEncryption(Encryption):
                 # pad the end chunk if necessary
                 padSize = 16 - (len(this_chunk) + FILE_LENGTH_FIELD_SIZE) % 16
                 padding = ' ' * padSize
-                this_chunk += padding
+                this_chunk += padding.encode()
                 this_chunk += file_length_field
                 is_final_chunk = True
 

--- a/cottoncandy/__init__.py
+++ b/cottoncandy/__init__.py
@@ -23,10 +23,11 @@ force_bucket_creation = string2bool(force_bucket_creation)
 
 encryption = options.config.get('encryption', 'method')
 doencryption = options.config.get('encryption', 'key')
-if string2bool(doencryption):
-    encryptionKey = b64decode()
-else:
+if doencryption in ['False', 'false', 'f', 'n', 'no', '0']:
     encryptionKey = False
+else:
+    # remove the `b'` and `'` introduced by str() during key gen
+    encryptionKey = b64decode(doencryption[2:-1])
 
 def get_interface(bucket_name=default_bucket,
                   ACCESS_KEY=ACCESS_KEY,

--- a/cottoncandy/interfaces.py
+++ b/cottoncandy/interfaces.py
@@ -1471,7 +1471,7 @@ class EncryptedInterface(DefaultInterface):
 
         if not object_name:
             object_name = local_file_name
-        with open(local_file_name) as f:
+        with open(local_file_name, 'rb') as f:
             return self.upload_object(object_name, f, ExtraArgs['ACL'])
 
     def download_to_file(self, object_name, file_name):

--- a/cottoncandy/options.py
+++ b/cottoncandy/options.py
@@ -96,6 +96,7 @@ Thanks for using cottoncandy!
     aesKey = config.get('encryption', 'key')
     if aesKey == 'auto':
         newKey = generate_AES_key()
+        # this prepends `b'` and appends `'` to the string
         aesKey = str(b64encode(newKey))
         config.set("encryption", 'key', aesKey)
 


### PR DESCRIPTION
While working on #91 I was unable to upload or download anything with an encrypted interface. This code should at least allow the test code below to run.

Given encryption has been broken I'm not sure if anyone has actually used it recently. This might break compatibility with existing encrypted objects, so I would appreciate if someone could test if you could read existing objects.

Note that these changes are only for Python <= 3.7, since PyCrypto depends on `time.clock` , [which was removed](https://docs.python.org/3.7/library/time.html#time.clock) in Python 3.8. Both this PR and #91 are necessary for supporting >= 3.8.

## Test code
I also did not see any automated tests for this, so here's a short snippet that should work:
```python
import os; import cottoncandy as cc; import numpy as np
cci = cc.get_encrypted_interface(os.environ['DL_BUCKET'], verbose=False, ACCESS_KEY=os.environ['DL_ACCESS_KEY'], SECRET_KEY=os.environ['DL_SECRET_KEY'], endpoint_url=os.environ['DL_URL'])
a = np.arange(10)
cci.upload_raw_array('test_array', a)
assert np.allclose(a, cci.download_raw_array(a))
```
I can enable all existing tests to also run for encrypted interfaces, but this doubles testing time so I haven't included it here (but I can if that's not an issue).
