### PR TITLE
FIX clean up empty dirs after rm/mv in localclient

### DIFF
--- a/cottoncandy/localclient.py
+++ b/cottoncandy/localclient.py
@@ -254,11 +254,12 @@ class LocalClient(CCBackEnd):
         source_metadata = os.path.join(source_bucket, source + METADATA_SUFFIX)
         destination_metadata = os.path.join(destination_bucket, destination + METADATA_SUFFIX)
         auto_makedirs(destination)
-        shutil.move(source, destination)
-        shutil.move(source_metadata, destination_metadata)
+        move_result = shutil.move(source, destination)
+        if os.path.isfile(source_metadata):
+            shutil.move(source_metadata, destination_metadata)
         # Clean up empty parent directories at source to mimic S3 behavior
         self._cleanup_empty_dirs(os.path.dirname(source), root_path=source_bucket)
-        return True
+        return move_result
 
     def delete(self, cloud_name, recursive=False, delete=False):
         """Deletes an object

--- a/cottoncandy/localclient.py
+++ b/cottoncandy/localclient.py
@@ -391,8 +391,6 @@ class LocalClient(CCBackEnd):
                 # Stop cleanup if the directory was removed or changed concurrently
                 break
 
-
-
 def auto_makedirs(destination: str) -> None:
     """Create directory tree if destination does not exist."""
     if not os.path.exists(os.path.dirname(destination)):

--- a/cottoncandy/localclient.py
+++ b/cottoncandy/localclient.py
@@ -368,14 +368,26 @@ class LocalClient(CCBackEnd):
         dir_path = os.path.normpath(dir_path)
         root_path = os.path.normpath(self.path)
 
+        # Ensure the directory is under the root path before attempting cleanup
+        try:
+            if os.path.commonpath([root_path, dir_path]) != root_path:
+                return
+        except ValueError:
+            # Paths on different drives or otherwise incomparable; do nothing
+            return
+
         # Walk up the directory tree
-        while dir_path != root_path and dir_path.startswith(root_path):
-            # Only remove if directory exists and is empty
-            if os.path.isdir(dir_path) and len(os.listdir(dir_path)) == 0:
-                os.rmdir(dir_path)
-                dir_path = os.path.dirname(dir_path)
-            else:
-                # Stop if directory is not empty or doesn't exist
+        while dir_path != root_path:
+            try:
+                # Only remove if directory exists and is empty
+                if os.path.isdir(dir_path) and len(os.listdir(dir_path)) == 0:
+                    os.rmdir(dir_path)
+                    dir_path = os.path.dirname(dir_path)
+                else:
+                    # Stop if directory is not empty or doesn't exist
+                    break
+            except OSError:
+                # Stop cleanup if the directory was removed or changed concurrently
                 break
 
 

--- a/cottoncandy/localclient.py
+++ b/cottoncandy/localclient.py
@@ -281,13 +281,14 @@ class LocalClient(CCBackEnd):
             cloud_metadata_name = cloud_name + METADATA_SUFFIX
             if os.path.isfile(cloud_metadata_name):
                 os.remove(cloud_metadata_name)
-            # Clean up empty parent directories to mimic S3 behavior
-            self._cleanup_empty_dirs(os.path.dirname(cloud_name))
         elif os.path.isdir(cloud_name):
             if recursive:
                 shutil.rmtree(cloud_name)
             else:
                 os.rmdir(cloud_name)
+
+        # Clean up empty parent directories to mimic S3 behavior
+        self._cleanup_empty_dirs(os.path.dirname(cloud_name))
 
         return True
 

--- a/cottoncandy/localclient.py
+++ b/cottoncandy/localclient.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 from io import BytesIO as StringIO
+from typing import Optional
 
 from .backend import CCBackEnd, CloudStream
 from .utils import SEPARATOR, remove_root, remove_trivial_magic, sanitize_metadata
@@ -17,7 +18,7 @@ class LocalClient(CCBackEnd):
     Handle metadata in CouldStream objects by storing a json file (.meta.json).
     """
 
-    def __init__(self, path):
+    def __init__(self, path: str):
         if not os.path.isdir(path):
             os.makedirs(path)
         self.path = path
@@ -256,7 +257,7 @@ class LocalClient(CCBackEnd):
         shutil.move(source, destination)
         shutil.move(source_metadata, destination_metadata)
         # Clean up empty parent directories at source to mimic S3 behavior
-        self._cleanup_empty_dirs(os.path.dirname(source))
+        self._cleanup_empty_dirs(os.path.dirname(source), root_path=source_bucket)
         return True
 
     def delete(self, cloud_name, recursive=False, delete=False):
@@ -353,7 +354,7 @@ class LocalClient(CCBackEnd):
         size = os.path.getsize(file_name)
         return size
 
-    def _cleanup_empty_dirs(self, dir_path: str) -> None:
+    def _cleanup_empty_dirs(self, dir_path: str, root_path: Optional[str] = None) -> None:
         """Remove empty parent directories up to self.path.
 
         This mimics S3 behavior where directories don't exist independently -
@@ -364,10 +365,14 @@ class LocalClient(CCBackEnd):
         ----------
         dir_path : str
             The directory path to start cleaning from
+        root_path : Optional[str]
+            The root path to stop cleaning at. If None, defaults to self.path.
         """
         # Normalize paths for comparison
         dir_path = os.path.normpath(dir_path)
-        root_path = os.path.normpath(self.path)
+        if root_path is None:
+            root_path = self.path
+        root_path = os.path.normpath(root_path)
 
         # Ensure the directory is under the root path before attempting cleanup
         try:

--- a/cottoncandy/localclient.py
+++ b/cottoncandy/localclient.py
@@ -253,7 +253,11 @@ class LocalClient(CCBackEnd):
         source_metadata = os.path.join(source_bucket, source + METADATA_SUFFIX)
         destination_metadata = os.path.join(destination_bucket, destination + METADATA_SUFFIX)
         auto_makedirs(destination)
-        return shutil.move(source, destination) and shutil.move(source_metadata, destination_metadata)
+        shutil.move(source, destination)
+        shutil.move(source_metadata, destination_metadata)
+        # Clean up empty parent directories at source to mimic S3 behavior
+        self._cleanup_empty_dirs(os.path.dirname(source))
+        return True
 
     def delete(self, cloud_name, recursive=False, delete=False):
         """Deletes an object
@@ -277,11 +281,15 @@ class LocalClient(CCBackEnd):
             cloud_metadata_name = cloud_name + METADATA_SUFFIX
             if os.path.isfile(cloud_metadata_name):
                 os.remove(cloud_metadata_name)
-        else:
+            # Clean up empty parent directories to mimic S3 behavior
+            self._cleanup_empty_dirs(os.path.dirname(cloud_name))
+        elif os.path.isdir(cloud_name):
             if recursive:
                 shutil.rmtree(cloud_name)
             else:
                 os.rmdir(cloud_name)
+
+        return True
 
     @property
     def size(self):
@@ -344,8 +352,35 @@ class LocalClient(CCBackEnd):
         size = os.path.getsize(file_name)
         return size
 
+    def _cleanup_empty_dirs(self, dir_path: str) -> None:
+        """Remove empty parent directories up to self.path.
 
-def auto_makedirs(destination):
+        This mimics S3 behavior where directories don't exist independently -
+        they only exist as part of object keys. When the last file in a
+        directory is deleted, the directory should disappear.
+
+        Parameters
+        ----------
+        dir_path : str
+            The directory path to start cleaning from
+        """
+        # Normalize paths for comparison
+        dir_path = os.path.normpath(dir_path)
+        root_path = os.path.normpath(self.path)
+
+        # Walk up the directory tree
+        while dir_path != root_path and dir_path.startswith(root_path):
+            # Only remove if directory exists and is empty
+            if os.path.isdir(dir_path) and len(os.listdir(dir_path)) == 0:
+                os.rmdir(dir_path)
+                dir_path = os.path.dirname(dir_path)
+            else:
+                # Stop if directory is not empty or doesn't exist
+                break
+
+
+
+def auto_makedirs(destination: str) -> None:
     """Create directory tree if destination does not exist."""
     if not os.path.exists(os.path.dirname(destination)):
         os.makedirs(os.path.dirname(destination))

--- a/cottoncandy/tests/test_localclient.py
+++ b/cottoncandy/tests/test_localclient.py
@@ -26,6 +26,7 @@ def test_delete_cleans_up_empty_directories(cci, object_name):
     assert not cci.exists_object(nested_file)
     assert not cci.exists_object(object_name + '/subdir1/subdir2')
     assert not cci.exists_object(object_name + '/subdir1')
+    assert len(cci.glob(object_name)) == 0
 
     # For local client, verify that empty parent directories are cleaned up on disk
     if isinstance(cci.backend_interface, LocalClient):
@@ -72,7 +73,7 @@ def test_move_cleans_up_empty_directories(cci, object_name):
     assert not cci.exists_object(source_file)
     assert not cci.exists_object(object_name + '/source/nested')
     assert not cci.exists_object(object_name + '/source')
-    assert cci.exists_object(dest_file)
+    assert cci.glob(object_name) == [dest_file]
 
     # For local client, verify that empty parent directories at source are cleaned up on disk
     if isinstance(cci.backend_interface, LocalClient):

--- a/cottoncandy/tests/test_localclient.py
+++ b/cottoncandy/tests/test_localclient.py
@@ -50,6 +50,26 @@ def test_delete_cleans_up_empty_directories(cci, object_name):
         and cci.download_object(object_name + '/subdir1') == content
     cci.rm(object_name + '/subdir1')
 
+    # Test recursive=True also cleans up empty directories
+    # Create the file again
+    cci.upload_object(nested_file, BytesIO(content))
+    time.sleep(cci.wait_time)
+
+    # Verify file exists
+    assert cci.exists_object(nested_file)
+
+    # Delete a subdir with recursive=True
+    cci.rm(object_name + '/subdir1', recursive=True)
+    time.sleep(cci.wait_time)
+
+    # Verify file is deleted
+    assert not cci.exists_object(nested_file)
+
+    # Verify empty directories are cleaned up (same checks as above)
+    if isinstance(cci.backend_interface, LocalClient):
+        object_path = Path(cci.backend_interface.path) / object_name
+        assert len(list(object_path.glob('**'))) == 0, "object_name dir should be removed after becoming empty"
+
 
 def test_move_cleans_up_empty_directories(cci, object_name):
     '''Test that moving a file also removes empty parent directories at source (S3-like behavior)'''

--- a/cottoncandy/tests/test_localclient.py
+++ b/cottoncandy/tests/test_localclient.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import os
 import time
 
 from ..localclient import LocalClient
@@ -15,7 +16,7 @@ def test_delete_cleans_up_empty_directories(cci, object_name):
     time.sleep(cci.wait_time)
 
     # Verify file exists
-    assert cci.exists_object(nested_file)
+    assert cci.exists_object(nested_file) and cci.download_object(nested_file) == content
 
     # Delete the file
     cci.rm(nested_file)
@@ -23,10 +24,11 @@ def test_delete_cleans_up_empty_directories(cci, object_name):
 
     # Verify file is deleted
     assert not cci.exists_object(nested_file)
+    assert not cci.exists_object(object_name + '/subdir1/subdir2')
+    assert not cci.exists_object(object_name + '/subdir1')
 
-    # For local client, verify that empty parent directories are cleaned up
+    # For local client, verify that empty parent directories are cleaned up on disk
     if isinstance(cci.backend_interface, LocalClient):
-        import os
         subdir2_path = os.path.join(cci.backend_interface.path, object_name, 'subdir1', 'subdir2')
         subdir1_path = os.path.join(cci.backend_interface.path, object_name, 'subdir1')
         object_path = os.path.join(cci.backend_interface.path, object_name)
@@ -35,6 +37,17 @@ def test_delete_cleans_up_empty_directories(cci, object_name):
         assert not os.path.exists(subdir2_path), "subdir2 should be removed after deleting its only file"
         assert not os.path.exists(subdir1_path), "subdir1 should be removed after becoming empty"
         assert not os.path.exists(object_path), "object_name dir should be removed after becoming empty"
+
+    # Try creating objects in place of the deleted directories.
+    cci.upload_object(object_name + '/subdir1/subdir2', BytesIO(content))
+    assert cci.exists_object(object_name + '/subdir1/subdir2') \
+        and cci.download_object(object_name + '/subdir1/subdir2') == content
+    cci.rm(object_name + '/subdir1/subdir2')
+
+    cci.upload_object(object_name + '/subdir1', BytesIO(content))
+    assert cci.exists_object(object_name + '/subdir1') \
+        and cci.download_object(object_name + '/subdir1') == content
+    cci.rm(object_name + '/subdir1')
 
 
 def test_move_cleans_up_empty_directories(cci, object_name):
@@ -57,11 +70,12 @@ def test_move_cleans_up_empty_directories(cci, object_name):
 
     # Verify file was moved
     assert not cci.exists_object(source_file)
+    assert not cci.exists_object(object_name + '/source/nested')
+    assert not cci.exists_object(object_name + '/source')
     assert cci.exists_object(dest_file)
 
-    # For local client, verify that empty parent directories at source are cleaned up
+    # For local client, verify that empty parent directories at source are cleaned up on disk
     if isinstance(cci.backend_interface, LocalClient):
-        import os
         source_nested_path = os.path.join(cci.backend_interface.path, object_name, 'source', 'nested')
         source_path = os.path.join(cci.backend_interface.path, object_name, 'source')
 
@@ -75,9 +89,19 @@ def test_move_cleans_up_empty_directories(cci, object_name):
 
     # Verify cleanup also works for destination
     if isinstance(cci.backend_interface, LocalClient):
-        import os
         dest_path = os.path.join(cci.backend_interface.path, object_name, 'dest')
         object_path = os.path.join(cci.backend_interface.path, object_name)
 
         assert not os.path.exists(dest_path), "dest dir should be removed after deleting its only file"
         assert not os.path.exists(object_path), "object_name dir should be removed after becoming empty"
+
+    # Try creating objects in place of the deleted directories.
+    cci.upload_object(object_name + '/source/nested', BytesIO(content))
+    assert cci.exists_object(object_name + '/source/nested') \
+        and cci.download_object(object_name + '/source/nested') == content
+    cci.rm(object_name + '/source/nested')
+
+    cci.upload_object(object_name + '/source', BytesIO(content))
+    assert cci.exists_object(object_name + '/source') \
+        and cci.download_object(object_name + '/source') == content
+    cci.rm(object_name + '/source')

--- a/cottoncandy/tests/test_localclient.py
+++ b/cottoncandy/tests/test_localclient.py
@@ -2,6 +2,8 @@ from io import BytesIO
 from pathlib import Path
 import time
 
+import cottoncandy as cc
+
 from ..localclient import LocalClient
 
 
@@ -134,3 +136,85 @@ def test_move_cleans_up_empty_directories(cci, object_name):
         and cci.download_object(object_name + '/source') == content
     cci.rm(object_name + '/source')
     time.sleep(cci.wait_time)
+
+
+def test_move_cleans_up_source_bucket_directories_across_buckets(tmp_path):
+    """Moving across buckets should remove empty source directories."""
+    source_bucket = tmp_path / 'source-bucket'
+    destination_bucket = tmp_path / 'destination-bucket'
+    source_bucket.mkdir()
+    destination_bucket.mkdir()
+
+    cci_src = cc.get_interface(
+        bucket_name=str(source_bucket),
+        backend='local',
+        verbose=False,
+    )
+    cci_dest = cc.get_interface(
+        bucket_name=str(destination_bucket),
+        backend='local',
+        verbose=False,
+    )
+    source_key = 'nested/a/b/file.txt'
+    destination_key = 'moved/file.txt'
+    content = b'cross bucket move content'
+
+    cci_src.upload_object(source_key, BytesIO(content))
+
+    source_root = source_bucket / 'nested'
+    source_a = source_root / 'a'
+    source_b = source_a / 'b'
+    source_file = source_b / 'file.txt'
+
+    assert source_file.exists()
+
+    # mv from src --> dest, calling from src client
+    cci_src.mv(
+        source_name=source_key,
+        dest_name=destination_key,
+        source_bucket=str(source_bucket),
+        dest_bucket=str(destination_bucket),
+        overwrite=True,
+    )
+
+    moved_file = destination_bucket / 'moved' / 'file.txt'
+    moved_metadata = destination_bucket / 'moved' / 'file.txt.meta.json'
+
+    assert moved_file.exists()
+    assert cci_dest.download_object(destination_key) == content
+    assert moved_metadata.exists()
+    assert not cci_src.exists_object(source_key, bucket_name=str(source_bucket))
+
+    # The source bucket should be cleaned up back to the bucket root.
+    assert not source_file.exists()
+    assert not source_b.exists()
+    assert not source_a.exists()
+    assert not source_root.exists()
+    assert source_bucket.exists()
+
+    # Cleanup
+    cci_dest.rm(destination_key)
+    assert not moved_file.exists()
+    assert not moved_metadata.exists()
+    assert not (destination_bucket / 'moved').exists()
+
+    # Now try the same thing, but calling `.mv()` from the destination client instead.
+    cci_src.upload_object(source_key, BytesIO(content))
+    cci_dest.mv(
+        source_name=source_key,
+        dest_name=destination_key,
+        source_bucket=str(source_bucket),
+        dest_bucket=str(destination_bucket),
+        overwrite=True,
+    )
+
+    assert moved_file.exists()
+    assert cci_dest.download_object(destination_key) == content
+    assert moved_metadata.exists()
+    assert not cci_src.exists_object(source_key, bucket_name=str(source_bucket))
+
+    assert not source_file.exists()
+    assert not source_b.exists()
+    assert not source_a.exists()
+    assert not source_root.exists()
+    assert source_bucket.exists()

--- a/cottoncandy/tests/test_localclient.py
+++ b/cottoncandy/tests/test_localclient.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-import os
+from pathlib import Path
 import time
 
 from ..localclient import LocalClient
@@ -29,14 +29,14 @@ def test_delete_cleans_up_empty_directories(cci, object_name):
 
     # For local client, verify that empty parent directories are cleaned up on disk
     if isinstance(cci.backend_interface, LocalClient):
-        subdir2_path = os.path.join(cci.backend_interface.path, object_name, 'subdir1', 'subdir2')
-        subdir1_path = os.path.join(cci.backend_interface.path, object_name, 'subdir1')
-        object_path = os.path.join(cci.backend_interface.path, object_name)
+        subdir2_path = Path(cci.backend_interface.path) / object_name / 'subdir1' / 'subdir2'
+        subdir1_path = Path(cci.backend_interface.path) / object_name / 'subdir1'
+        object_path = Path(cci.backend_interface.path) / object_name
 
         # Verify all empty directories were removed
-        assert not os.path.exists(subdir2_path), "subdir2 should be removed after deleting its only file"
-        assert not os.path.exists(subdir1_path), "subdir1 should be removed after becoming empty"
-        assert not os.path.exists(object_path), "object_name dir should be removed after becoming empty"
+        assert not subdir2_path.exists(), "subdir2 should be removed after deleting its only file"
+        assert not subdir1_path.exists(), "subdir1 should be removed after becoming empty"
+        assert not object_path.exists(), "object_name dir should be removed after becoming empty"
 
     # Try creating objects in place of the deleted directories.
     cci.upload_object(object_name + '/subdir1/subdir2', BytesIO(content))
@@ -76,12 +76,12 @@ def test_move_cleans_up_empty_directories(cci, object_name):
 
     # For local client, verify that empty parent directories at source are cleaned up on disk
     if isinstance(cci.backend_interface, LocalClient):
-        source_nested_path = os.path.join(cci.backend_interface.path, object_name, 'source', 'nested')
-        source_path = os.path.join(cci.backend_interface.path, object_name, 'source')
+        source_nested_path = Path(cci.backend_interface.path) / object_name / 'source' / 'nested'
+        source_path = Path(cci.backend_interface.path) / object_name / 'source'
 
         # Verify empty directories at source were removed
-        assert not os.path.exists(source_nested_path), "source/nested should be removed after moving its only file"
-        assert not os.path.exists(source_path), "source should be removed after becoming empty"
+        assert not source_nested_path.exists(), "source/nested should be removed after moving its only file"
+        assert not source_path.exists(), "source should be removed after becoming empty"
 
     # Clean up
     cci.rm(dest_file)
@@ -89,11 +89,11 @@ def test_move_cleans_up_empty_directories(cci, object_name):
 
     # Verify cleanup also works for destination
     if isinstance(cci.backend_interface, LocalClient):
-        dest_path = os.path.join(cci.backend_interface.path, object_name, 'dest')
-        object_path = os.path.join(cci.backend_interface.path, object_name)
+        dest_path = Path(cci.backend_interface.path) / object_name / 'dest'
+        object_path = Path(cci.backend_interface.path) / object_name
 
-        assert not os.path.exists(dest_path), "dest dir should be removed after deleting its only file"
-        assert not os.path.exists(object_path), "object_name dir should be removed after becoming empty"
+        assert not dest_path.exists(), "dest dir should be removed after deleting its only file"
+        assert not object_path.exists(), "object_name dir should be removed after becoming empty"
 
     # Try creating objects in place of the deleted directories.
     cci.upload_object(object_name + '/source/nested', BytesIO(content))

--- a/cottoncandy/tests/test_localclient.py
+++ b/cottoncandy/tests/test_localclient.py
@@ -1,0 +1,83 @@
+from io import BytesIO
+import time
+
+from ..localclient import LocalClient
+
+
+def test_delete_cleans_up_empty_directories(cci, object_name):
+    '''Test that deleting a file also removes empty parent directories (S3-like behavior)'''
+    # Create a file in nested directories
+    nested_file = object_name + '/subdir1/subdir2/file.txt'
+    content = b'test content'
+
+    # Upload the file
+    cci.upload_object(nested_file, BytesIO(content))
+    time.sleep(cci.wait_time)
+
+    # Verify file exists
+    assert cci.exists_object(nested_file)
+
+    # Delete the file
+    cci.rm(nested_file)
+    time.sleep(cci.wait_time)
+
+    # Verify file is deleted
+    assert not cci.exists_object(nested_file)
+
+    # For local client, verify that empty parent directories are cleaned up
+    if isinstance(cci.backend_interface, LocalClient):
+        import os
+        subdir2_path = os.path.join(cci.backend_interface.path, object_name, 'subdir1', 'subdir2')
+        subdir1_path = os.path.join(cci.backend_interface.path, object_name, 'subdir1')
+        object_path = os.path.join(cci.backend_interface.path, object_name)
+
+        # Verify all empty directories were removed
+        assert not os.path.exists(subdir2_path), "subdir2 should be removed after deleting its only file"
+        assert not os.path.exists(subdir1_path), "subdir1 should be removed after becoming empty"
+        assert not os.path.exists(object_path), "object_name dir should be removed after becoming empty"
+
+
+def test_move_cleans_up_empty_directories(cci, object_name):
+    '''Test that moving a file also removes empty parent directories at source (S3-like behavior)'''
+    # Create a file in nested directories
+    source_file = object_name + '/source/nested/file.txt'
+    dest_file = object_name + '/dest/file.txt'
+    content = b'test content for move'
+
+    # Upload the file
+    cci.upload_object(source_file, BytesIO(content))
+    time.sleep(cci.wait_time)
+
+    # Verify file exists
+    assert cci.exists_object(source_file)
+
+    # Move the file
+    cci.mv(source_file, dest_file, overwrite=True)
+    time.sleep(cci.wait_time)
+
+    # Verify file was moved
+    assert not cci.exists_object(source_file)
+    assert cci.exists_object(dest_file)
+
+    # For local client, verify that empty parent directories at source are cleaned up
+    if isinstance(cci.backend_interface, LocalClient):
+        import os
+        source_nested_path = os.path.join(cci.backend_interface.path, object_name, 'source', 'nested')
+        source_path = os.path.join(cci.backend_interface.path, object_name, 'source')
+
+        # Verify empty directories at source were removed
+        assert not os.path.exists(source_nested_path), "source/nested should be removed after moving its only file"
+        assert not os.path.exists(source_path), "source should be removed after becoming empty"
+
+    # Clean up
+    cci.rm(dest_file)
+    time.sleep(cci.wait_time)
+
+    # Verify cleanup also works for destination
+    if isinstance(cci.backend_interface, LocalClient):
+        import os
+        dest_path = os.path.join(cci.backend_interface.path, object_name, 'dest')
+        object_path = os.path.join(cci.backend_interface.path, object_name)
+
+        assert not os.path.exists(dest_path), "dest dir should be removed after deleting its only file"
+        assert not os.path.exists(object_path), "object_name dir should be removed after becoming empty"

--- a/cottoncandy/tests/test_localclient.py
+++ b/cottoncandy/tests/test_localclient.py
@@ -41,14 +41,18 @@ def test_delete_cleans_up_empty_directories(cci, object_name):
 
     # Try creating objects in place of the deleted directories.
     cci.upload_object(object_name + '/subdir1/subdir2', BytesIO(content))
+    time.sleep(cci.wait_time)
     assert cci.exists_object(object_name + '/subdir1/subdir2') \
         and cci.download_object(object_name + '/subdir1/subdir2') == content
     cci.rm(object_name + '/subdir1/subdir2')
+    time.sleep(cci.wait_time)
 
     cci.upload_object(object_name + '/subdir1', BytesIO(content))
+    time.sleep(cci.wait_time)
     assert cci.exists_object(object_name + '/subdir1') \
         and cci.download_object(object_name + '/subdir1') == content
     cci.rm(object_name + '/subdir1')
+    time.sleep(cci.wait_time)
 
     # Test recursive=True also cleans up empty directories
     # Create the file again
@@ -118,11 +122,15 @@ def test_move_cleans_up_empty_directories(cci, object_name):
 
     # Try creating objects in place of the deleted directories.
     cci.upload_object(object_name + '/source/nested', BytesIO(content))
+    time.sleep(cci.wait_time)
     assert cci.exists_object(object_name + '/source/nested') \
         and cci.download_object(object_name + '/source/nested') == content
     cci.rm(object_name + '/source/nested')
+    time.sleep(cci.wait_time)
 
     cci.upload_object(object_name + '/source', BytesIO(content))
+    time.sleep(cci.wait_time)
     assert cci.exists_object(object_name + '/source') \
         and cci.download_object(object_name + '/source') == content
     cci.rm(object_name + '/source')
+    time.sleep(cci.wait_time)


### PR DESCRIPTION
I pushed my branch to this repo, since CI was not running correctly on my fork.


---

From #116:

If we don't do this, this sequence of operations fails (but shouldn't for S3) because `a/` still exists as a directory:

```python
cci.upload_raw_array("a/b", np.zeros(10))
cci.rm("a/b")
cci.upload_raw_array("a", np.zeros(10))
```