### PR TITLE
CI build documentation automatically

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,50 @@
+name: Build docs
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: 3.9
+
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y rpl 
+        pip install --upgrade pip
+        pip install setuptools wheel
+        pip install -e .[extra] --group docs
+        python -c 'import cottoncandy; print(cottoncandy.__version__)' # create config
+
+    - name: Build documents
+      run: |
+        cd gendoc && make githubio-docs && cd ..
+        touch docs/.nojekyll
+
+    - name: Publish to gh-pages if tagged
+      if: startsWith(github.ref, 'refs/tags')
+      uses: JamesIves/github-pages-deploy-action@v4.8.0
+      with:
+        branch: gh-pages
+        folder: docs

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -9,7 +9,8 @@ on:
   pull_request:
     branches:
       - main
-
+  workflow_dispatch:  # Manual trigger for publishing docs
+  
 jobs:
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         python-version: 3.9
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -30,8 +30,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y rpl 
         pip install --upgrade pip
         pip install setuptools wheel
         pip install -e .[extra] --group docs

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/cache@v5
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 

--- a/gendoc/remove_keys.py
+++ b/gendoc/remove_keys.py
@@ -25,9 +25,7 @@ files_changed = 0
 errors = []
 
 def should_replace(word):
-    if isinstance(word, bool) or (word is None) or (not isinstance(word, str)):
-        return False
-    return len(word) != 0
+    return isinstance(word, str) and len(word) > 0
 
 def sanitize_file(file_path, replacements):
     global files_sanitized, files_changed

--- a/gendoc/remove_keys.py
+++ b/gendoc/remove_keys.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 
 from cottoncandy import options
@@ -41,7 +42,7 @@ def sanitize_file(file_path, replacements):
     for word, replacement in replacements.items():
         if not should_replace(word):
             continue
-        content = content.replace(word, replacement)
+        content = re.sub(re.escape(word), replacement, content, flags=re.IGNORECASE)
 
     if content == original:
         files_sanitized += 1

--- a/gendoc/remove_keys.py
+++ b/gendoc/remove_keys.py
@@ -32,7 +32,7 @@ def should_replace(word):
 def sanitize_file(file_path, replacements):
     global files_sanitized, files_changed
     try:
-        with open(file_path, "r", encoding="utf-8", errors="ignore") as handle:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as handle:
             content = handle.read()
     except OSError:
         errors.append(file_path)
@@ -49,7 +49,7 @@ def sanitize_file(file_path, replacements):
         return
 
     try:
-        with open(file_path, "w", encoding="utf-8", errors="ignore") as handle:
+        with open(file_path, "w", encoding="utf-8", errors="replace") as handle:
             handle.write(content)
         files_sanitized += 1
         files_changed += 1

--- a/gendoc/remove_keys.py
+++ b/gendoc/remove_keys.py
@@ -6,6 +6,10 @@ from cottoncandy import options
 args = sys.argv
 paths_to_search_list = args[1:]
 
+if len(paths_to_search_list) == 0:
+    print("No paths provided; nothing to sanitize.")
+    sys.exit(1)
+
 replacement_dict = {
     options.config.get('login', 'access_key'): "FAKE_ACCESS_KEY",
     options.config.get('login', 'secret_key'): "FAKE_SECRET_KEY",
@@ -13,14 +17,60 @@ replacement_dict = {
     options.config.get('basic', 'default_bucket'): "FAKE_DEFAULT_BUCKET",
     }
 
-max_depth = 4
-intermediate_path = ""
-for depth in range(max_depth):
-    intermediate_path = os.path.join(intermediate_path, "**")
-    for path_to_search in paths_to_search_list:
-        "Searching files in {path_to_search}".format(path_to_search=path_to_search)
-        for suffix in ["html", "js", "txt"]:
-            for word, replacement in replacement_dict.items():
-                cmd = "rpl -iR {word} {replacement} {path_to_search}".format(word=word, replacement=replacement, path_to_search=os.path.join(path_to_search, intermediate_path, "*.{suffix}".format(suffix=suffix)))
-                print(cmd)
-                print(os.system(cmd))
+suffixes = {".html", ".js", ".txt"}
+
+files_sanitized = 0
+files_changed = 0
+errors = []
+
+def should_replace(word):
+    if isinstance(word, bool) or (word is None) or (len(word) == 0):
+        return False
+    return isinstance(word, str)
+
+def sanitize_file(file_path, replacements):
+    global files_sanitized, files_changed
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as handle:
+            content = handle.read()
+    except OSError:
+        errors.append(file_path)
+        return
+
+    original = content
+    for word, replacement in replacements.items():
+        if not should_replace(word):
+            continue
+        content = content.replace(word, replacement)
+
+    files_sanitized += 1
+    if content == original:
+        return
+
+    try:
+        with open(file_path, "w", encoding="utf-8", errors="ignore") as handle:
+            handle.write(content)
+        files_changed += 1
+    except OSError:
+        errors.append(file_path)
+
+for path_to_search in paths_to_search_list:
+    if not os.path.exists(path_to_search):
+        errors.append(path_to_search)
+        continue
+
+    for root, _, files in os.walk(path_to_search):
+        for filename in files:
+            if os.path.splitext(filename)[1] not in suffixes:
+                continue
+            sanitize_file(os.path.join(root, filename), replacement_dict)
+
+print("Sanitized {count} files; updated {changed} files; {errors} errors.".format(
+    count=files_sanitized,
+    changed=files_changed,
+    errors=len(errors),
+))
+
+if len(errors) > 0:
+    print("Sanitization failed; see file access errors in logs.")
+    sys.exit(1)

--- a/gendoc/remove_keys.py
+++ b/gendoc/remove_keys.py
@@ -24,9 +24,9 @@ files_changed = 0
 errors = []
 
 def should_replace(word):
-    if isinstance(word, bool) or (word is None) or (len(word) == 0):
+    if isinstance(word, bool) or (word is None) or (not isinstance(word, str)):
         return False
-    return isinstance(word, str)
+    return len(word) != 0
 
 def sanitize_file(file_path, replacements):
     global files_sanitized, files_changed
@@ -43,13 +43,14 @@ def sanitize_file(file_path, replacements):
             continue
         content = content.replace(word, replacement)
 
-    files_sanitized += 1
     if content == original:
+        files_sanitized += 1
         return
 
     try:
         with open(file_path, "w", encoding="utf-8", errors="ignore") as handle:
             handle.write(content)
+        files_sanitized += 1
         files_changed += 1
     except OSError:
         errors.append(file_path)

--- a/gendoc/tools/build_modref_templates.py
+++ b/gendoc/tools/build_modref_templates.py
@@ -11,7 +11,7 @@ from os.path import join as pjoin
 from apigen import ApiDocWriter
 
 # version comparison
-from distutils.version import LooseVersion as V
+from looseversion import LooseVersion as V
 
 # *****************************************************************************
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ test = [
     "pytest-rerunfailures",
 ]
 docs = [
+    "looseversion",
+    "numpydoc",
     "sphinx",
+    "sphinx_bootstrap_theme",
     "sphinx-rtd-theme",
 ]
 dev = [


### PR DESCRIPTION
This PR adds a new workflow to build documentation and push to GitHub Pages on tagged commits. (Fixes #104.)

It also replaces the previous key scrubbing script to avoid leaking keys in the Actions logs (`gendoc/remove_keys.py`). I've confirmed locally that it doesn't output any keys.