### PR TITLE
Add multiple selectable config profiles to get_interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,41 @@ By default, cottoncandy sets object and bucket permissions to ``authenticated-re
 
 Advanced (for admins): One can customize the cottoncandy system install by cloning the repo and modifying `defaults.cfg`. For example, one can set the default encryption key across the system for all users (`key = SoMeEncypTionKey`). When a user first uses cottoncandy, this default value will be copied to their personal configuration file. Note however that the user can still overwrite that value.
 
+### Profiles
+
+If you work across multiple accounts, endpoints, or buckets, you can define named
+**profiles** in your configuration file and select one when creating an interface:
+
+```python
+>>> cci = cc.get_interface(profile='mylab')
+```
+
+Each profile is a `[profile:NAME]` section that may set any subset of
+`access_key`, `secret_key`, `endpoint_url`, `default_bucket`, `signature_version`,
+`force_bucket_creation`, `backend`, and (for `backend = gdrive`) `secrets` and
+`credentials`. Any setting a profile omits falls back to the base
+`[login]`/`[basic]`/`[gdrive]` sections (the default profile, used when no
+`profile` is given). Arguments passed directly to `get_interface` always take
+precedence over the profile.
+
+Profiles can **inherit** from one another with `inherits`; a child only needs to
+specify the keys it overrides:
+
+```ini
+[profile:mylab]
+access_key = LABACCESSKEY
+secret_key = LABSECRETKEY
+endpoint_url = https://s3.example.edu/
+default_bucket = lab-shared
+
+[profile:mylab-scratch]
+inherits = mylab
+default_bucket = lab-scratch
+```
+
+Use `cottoncandy.options.list_profiles()` to see the profiles defined in your
+configuration.
+
 
 ## Getting started
 Setup the connection (endpoint, access and secret keys can be specified in the configuration file instead):

--- a/cottoncandy/__init__.py
+++ b/cottoncandy/__init__.py
@@ -162,7 +162,7 @@ def get_browser(bucket_name=None,
     if endpoint_url is None:
         endpoint_url = settings['endpoint_url']
 
-    if ACCESS_KEY in [False, "False"] and SECRET_KEY in [False, "False"]:
+    if ACCESS_KEY in [False, "False", None] and SECRET_KEY in [False, "False", None]:
         from .utils import get_keys
         ACCESS_KEY, SECRET_KEY = get_keys()
 

--- a/cottoncandy/__init__.py
+++ b/cottoncandy/__init__.py
@@ -153,6 +153,9 @@ def get_browser(bucket_name=None,
     # Resolve the profile (falls back to the base config sections); explicitly
     # passed arguments win over the profile.
     settings = options.get_profile(profile)
+    backend = settings['backend'] or 's3'
+    if backend != 's3':
+        raise ValueError("get_browser only supports the 's3' backend; got %r" % backend)
     if bucket_name is None:
         bucket_name = settings['default_bucket']
     if ACCESS_KEY is None:

--- a/cottoncandy/__init__.py
+++ b/cottoncandy/__init__.py
@@ -80,7 +80,7 @@ def get_interface(bucket_name=None,
     signature_version = settings['signature_version']
 
     if backend == 's3':
-        if ACCESS_KEY in [False, "False"] or SECRET_KEY in [False, "False"]:
+        if ACCESS_KEY in [False, "False", None] or SECRET_KEY in [False, "False", None]:
             ACCESS_KEY, SECRET_KEY = get_keys()
     elif backend == 'gdrive':
         ACCESS_KEY = os.path.join(options.userdir, settings['secrets'])

--- a/cottoncandy/__init__.py
+++ b/cottoncandy/__init__.py
@@ -21,13 +21,14 @@ force_bucket_creation = options.config.get('basic', 'force_bucket_creation')
 force_bucket_creation = string2bool(force_bucket_creation)
 
 
-def get_interface(bucket_name=default_bucket,
-                  ACCESS_KEY=ACCESS_KEY,
-                  SECRET_KEY=SECRET_KEY,
-                  endpoint_url=ENDPOINT_URL,
-                  force_bucket_creation=force_bucket_creation,
+def get_interface(bucket_name=None,
+                  ACCESS_KEY=None,
+                  SECRET_KEY=None,
+                  endpoint_url=None,
+                  force_bucket_creation=None,
                   verbose=True,
-                  backend='s3',
+                  backend=None,
+                  profile=None,
                   **kwargs):
     """Return an interface to the cloud.
 
@@ -40,6 +41,13 @@ def get_interface(bucket_name=default_bucket,
         The URL for the S3 gateway
     backend : 's3'|'gdrive'
         What backend to hook on to
+    profile : str, optional
+        Name of a ``[profile:NAME]`` section in the configuration file from
+        which to read the connection settings (access/secret keys, endpoint,
+        bucket, signature version, backend, gdrive credentials). Any setting a
+        profile omits falls back to the base ``[login]``/``[basic]``/``[gdrive]``
+        sections. Explicitly-passed arguments always take precedence over the
+        profile. See ``cottoncandy.options.list_profiles``.
     kwargs :
         S3 only. kwargs passed to botocore. For example,
         >>> from botocore.client import Config
@@ -52,12 +60,31 @@ def get_interface(bucket_name=default_bucket,
     """
     from cottoncandy.interfaces import DefaultInterface
 
+    # Resolve the profile (falls back to the base config sections). Any
+    # argument left as ``None`` is filled in from the resolved settings, so
+    # explicitly-passed arguments always win over the profile/config.
+    settings = options.get_profile(profile)
+
+    if bucket_name is None:
+        bucket_name = settings['default_bucket']
+    if ACCESS_KEY is None:
+        ACCESS_KEY = settings['access_key']
+    if SECRET_KEY is None:
+        SECRET_KEY = settings['secret_key']
+    if endpoint_url is None:
+        endpoint_url = settings['endpoint_url']
+    if backend is None:
+        backend = settings['backend'] or 's3'
+    if force_bucket_creation is None:
+        force_bucket_creation = string2bool(settings['force_bucket_creation'])
+    signature_version = settings['signature_version']
+
     if backend == 's3':
         if ACCESS_KEY in [False, "False"] or SECRET_KEY in [False, "False"]:
             ACCESS_KEY, SECRET_KEY = get_keys()
     elif backend == 'gdrive':
-        ACCESS_KEY = os.path.join(options.userdir, options.config.get('gdrive', 'secrets'))
-        SECRET_KEY = os.path.join(options.userdir, options.config.get('gdrive', 'credentials'))
+        ACCESS_KEY = os.path.join(options.userdir, settings['secrets'])
+        SECRET_KEY = os.path.join(options.userdir, settings['credentials'])
     else:
         pass
 
@@ -65,11 +92,11 @@ def get_interface(bucket_name=default_bucket,
         # user provided config
         if not kwargs['config'].signature_version:
             # config does not specify signature
-            kwargs['config'].signature_version = DEFAULT_SIGNATURE_VERSION
-    elif DEFAULT_SIGNATURE_VERSION:
+            kwargs['config'].signature_version = signature_version
+    elif signature_version:
         # no config but default signature exists
         from botocore.client import Config
-        kwargs['config'] = Config(signature_version=DEFAULT_SIGNATURE_VERSION)
+        kwargs['config'] = Config(signature_version=signature_version)
 
     interface = DefaultInterface(bucket_name,
                                  ACCESS_KEY,
@@ -77,15 +104,16 @@ def get_interface(bucket_name=default_bucket,
                                  endpoint_url,
                                  force_bucket_creation,
                                  verbose=verbose,
-                                 backend = backend,
+                                 backend=backend,
                                  **kwargs)
     return interface
 
 
-def get_browser(bucket_name=default_bucket,
-                ACCESS_KEY=ACCESS_KEY,
-                SECRET_KEY=SECRET_KEY,
-                endpoint_url=ENDPOINT_URL):
+def get_browser(bucket_name=None,
+                ACCESS_KEY=None,
+                SECRET_KEY=None,
+                endpoint_url=None,
+                profile=None):
     """Browser object that allows you to tab-complete your
     way through your objects
 
@@ -96,6 +124,10 @@ def get_browser(bucket_name=default_bucket,
     SECRET_KEY : str
     endpoint_url : str
         The URL for the S3 gateway
+    profile : str, optional
+        Name of a ``[profile:NAME]`` section in the configuration file from
+        which to read the connection settings. Explicitly-passed arguments take
+        precedence over the profile. See ``cottoncandy.options.list_profiles``.
 
     Returns
     -------
@@ -118,7 +150,19 @@ def get_browser(bucket_name=default_bucket,
     from cottoncandy.browser import S3Directory
     from cottoncandy.interfaces import DefaultInterface
 
-    if (ACCESS_KEY is False) and (SECRET_KEY is False):
+    # Resolve the profile (falls back to the base config sections); explicitly
+    # passed arguments win over the profile.
+    settings = options.get_profile(profile)
+    if bucket_name is None:
+        bucket_name = settings['default_bucket']
+    if ACCESS_KEY is None:
+        ACCESS_KEY = settings['access_key']
+    if SECRET_KEY is None:
+        SECRET_KEY = settings['secret_key']
+    if endpoint_url is None:
+        endpoint_url = settings['endpoint_url']
+
+    if ACCESS_KEY in [False, "False"] and SECRET_KEY in [False, "False"]:
         from .utils import get_keys
         ACCESS_KEY, SECRET_KEY = get_keys()
 

--- a/cottoncandy/__init__.py
+++ b/cottoncandy/__init__.py
@@ -39,7 +39,7 @@ def get_interface(bucket_name=None,
     SECRET_KEY : str
     endpoint_url : str
         The URL for the S3 gateway
-    backend : 's3'|'gdrive'
+    backend : 's3'|'gdrive'|'local'
         What backend to hook on to
     profile : str, optional
         Name of a ``[profile:NAME]`` section in the configuration file from

--- a/cottoncandy/defaults.cfg
+++ b/cottoncandy/defaults.cfg
@@ -13,6 +13,8 @@ force_bucket_creation = False
 path_separator = /
 signature_version =
 threads = 4
+# default backend: 's3', 'gdrive', or 'local'
+backend = s3
 
 [upload_settings]
 # in MB, except max_mpu_size_TB, and max_mpu_parts
@@ -43,3 +45,29 @@ do_compression = True
 small_array = gzip
 # >= 2 GB arrays
 large_array = Zstd
+
+# Profiles (optional)
+# -------------------
+# Define named profiles to switch between accounts/endpoints/buckets:
+#
+#     cci = cottoncandy.get_interface(profile='mylab')
+#
+# A profile section is named [profile:NAME] and may set any subset of:
+#     access_key, secret_key, endpoint_url, default_bucket,
+#     signature_version, force_bucket_creation, backend,
+#     secrets, credentials   (the last two are for backend = gdrive)
+# Anything a profile omits falls back to the [login]/[basic]/[gdrive] sections
+# above (the default profile).
+#
+# A profile can inherit from another profile with `inherits`; a child only needs
+# to specify the keys it overrides:
+#
+# [profile:mylab]
+# access_key = LABACCESSKEY
+# secret_key = LABSECRETKEY
+# endpoint_url = https://s3.example.edu/
+# default_bucket = lab-shared
+#
+# [profile:mylab-scratch]
+# inherits = mylab
+# default_bucket = lab-scratch

--- a/cottoncandy/options.py
+++ b/cottoncandy/options.py
@@ -84,3 +84,103 @@ else:
     if needs_update:
         with open(usercfg, 'w') as configfile:
             config.write(configfile)
+
+
+# Profiles
+# --------
+# A profile bundles the connection-identity settings so users can switch
+# between accounts/endpoints/buckets via ``get_interface(profile='NAME')``.
+# Each profile lives in its own ``[profile:NAME]`` section and may set any
+# subset of the keys below. Anything a profile omits falls back to the base
+# ``[login]``/``[basic]``/``[gdrive]`` sections (the default profile). A profile
+# can inherit from another with ``inherits = PARENT`` and only specify the keys
+# it overrides.
+PROFILE_PREFIX = 'profile:'
+INHERITS_KEY = 'inherits'
+
+# logical name -> (base section, key) used as the default-profile fallback
+PROFILE_KEYS = {
+    'access_key': ('login', 'access_key'),
+    'secret_key': ('login', 'secret_key'),
+    'endpoint_url': ('login', 'endpoint_url'),
+    'default_bucket': ('basic', 'default_bucket'),
+    'signature_version': ('basic', 'signature_version'),
+    'force_bucket_creation': ('basic', 'force_bucket_creation'),
+    'backend': ('basic', 'backend'),
+    'secrets': ('gdrive', 'secrets'),
+    'credentials': ('gdrive', 'credentials'),
+}
+
+
+def list_profiles(cfg=None):
+    '''List the names of the profiles defined in the configuration.
+
+    Parameters
+    ----------
+    cfg : configparser.ConfigParser, optional
+        Defaults to the global cottoncandy config.
+
+    Returns
+    -------
+    profiles : list of str
+    '''
+    cfg = config if cfg is None else cfg
+    return [section[len(PROFILE_PREFIX):] for section in cfg.sections()
+            if section.startswith(PROFILE_PREFIX)]
+
+
+def _profile_chain(name, cfg, _seen=None):
+    '''Return the inheritance chain for a profile, root parent first.
+
+    Raises
+    ------
+    ValueError
+        If the profile (or a parent) does not exist, or if the ``inherits``
+        relationships form a cycle.
+    '''
+    _seen = [] if _seen is None else _seen
+    section = PROFILE_PREFIX + name
+    if not cfg.has_section(section):
+        raise ValueError('Unknown cottoncandy profile %r. Available: %s'
+                         % (name, list_profiles(cfg)))
+    if name in _seen:
+        raise ValueError('Circular profile inheritance: %s'
+                         % ' -> '.join(_seen + [name]))
+    _seen = _seen + [name]
+    if cfg.has_option(section, INHERITS_KEY):
+        parent = cfg.get(section, INHERITS_KEY).strip()
+        if parent:
+            return _profile_chain(parent, cfg, _seen) + [name]
+    return [name]
+
+
+def get_profile(name=None, cfg=None):
+    '''Resolve a profile into a dict of connection settings.
+
+    Values are resolved most-specific-last: the base ``[login]``/``[basic]``/
+    ``[gdrive]`` sections provide the defaults, then each profile in the
+    inheritance chain (root parent first) overlays the keys it sets.
+
+    Parameters
+    ----------
+    name : str or None
+        Profile name. ``None`` returns the base/default settings.
+    cfg : configparser.ConfigParser, optional
+        Defaults to the global cottoncandy config.
+
+    Returns
+    -------
+    settings : dict
+        Keys are those of ``PROFILE_KEYS``; missing values are ``None``.
+    '''
+    cfg = config if cfg is None else cfg
+    settings = {key: (cfg.get(section, option)
+                      if cfg.has_option(section, option) else None)
+                for key, (section, option) in PROFILE_KEYS.items()}
+    if name:
+        for profile_name in _profile_chain(name, cfg):
+            section = PROFILE_PREFIX + profile_name
+            for key in PROFILE_KEYS:
+                if cfg.has_option(section, key):
+                    settings[key] = cfg.get(section, key)
+    return settings

--- a/cottoncandy/tests/test_options.py
+++ b/cottoncandy/tests/test_options.py
@@ -1,0 +1,164 @@
+"""Tests for the configuration profile resolution in ``cottoncandy.options``.
+
+These tests build an in-memory ``ConfigParser`` and resolve profiles against it,
+so they do not touch the user's real configuration file or any network backend.
+"""
+import configparser
+
+import pytest
+
+import cottoncandy as cc
+import cottoncandy.interfaces
+from cottoncandy import options
+
+
+def make_config():
+    """Base sections plus a handful of profiles used across the tests."""
+    cfg = configparser.ConfigParser()
+    cfg.read_dict({
+        'login': {
+            'access_key': 'BASEACCESS',
+            'secret_key': 'BASESECRET',
+            'endpoint_url': 'https://s3.amazonaws.com/',
+        },
+        'basic': {
+            'default_bucket': 'base-bucket',
+            'signature_version': '',
+            'force_bucket_creation': 'False',
+            'backend': 's3',
+        },
+        'gdrive': {
+            'secrets': 'client_secrets.json',
+            'credentials': 'credentials.txt',
+        },
+        'profile:lab': {
+            'access_key': 'LABACCESS',
+            'secret_key': 'LABSECRET',
+            'endpoint_url': 'https://s3.example.edu/',
+            'default_bucket': 'lab-shared',
+        },
+        'profile:lab-scratch': {
+            'inherits': 'lab',
+            'default_bucket': 'lab-scratch',
+        },
+        'profile:lab-scratch-ro': {
+            'inherits': 'lab-scratch',
+            'signature_version': 's3v4',
+        },
+        'profile:drive': {
+            'backend': 'gdrive',
+            'secrets': 'lab_secrets.json',
+            'credentials': 'lab_creds.txt',
+        },
+        'profile:cycle-a': {'inherits': 'cycle-b'},
+        'profile:cycle-b': {'inherits': 'cycle-a'},
+    })
+    return cfg
+
+
+def test_default_profile_uses_base_sections():
+    cfg = make_config()
+    settings = options.get_profile(None, cfg=cfg)
+    assert settings['access_key'] == 'BASEACCESS'
+    assert settings['secret_key'] == 'BASESECRET'
+    assert settings['endpoint_url'] == 'https://s3.amazonaws.com/'
+    assert settings['default_bucket'] == 'base-bucket'
+    assert settings['backend'] == 's3'
+
+
+def test_profile_overrides_only_specified_keys():
+    cfg = make_config()
+    settings = options.get_profile('lab', cfg=cfg)
+    # set by the profile
+    assert settings['access_key'] == 'LABACCESS'
+    assert settings['endpoint_url'] == 'https://s3.example.edu/'
+    assert settings['default_bucket'] == 'lab-shared'
+    # not set by the profile -> falls back to the base sections
+    assert settings['backend'] == 's3'
+    assert settings['force_bucket_creation'] == 'False'
+
+
+def test_inheritance_single_level():
+    cfg = make_config()
+    settings = options.get_profile('lab-scratch', cfg=cfg)
+    # inherited from the parent profile (lab)
+    assert settings['access_key'] == 'LABACCESS'
+    assert settings['endpoint_url'] == 'https://s3.example.edu/'
+    # overridden by the child
+    assert settings['default_bucket'] == 'lab-scratch'
+
+
+def test_inheritance_multi_level():
+    cfg = make_config()
+    settings = options.get_profile('lab-scratch-ro', cfg=cfg)
+    assert settings['access_key'] == 'LABACCESS'        # from lab
+    assert settings['default_bucket'] == 'lab-scratch'  # from lab-scratch
+    assert settings['signature_version'] == 's3v4'      # own
+
+
+def test_gdrive_profile():
+    cfg = make_config()
+    settings = options.get_profile('drive', cfg=cfg)
+    assert settings['backend'] == 'gdrive'
+    assert settings['secrets'] == 'lab_secrets.json'
+    assert settings['credentials'] == 'lab_creds.txt'
+
+
+def test_unknown_profile_raises():
+    cfg = make_config()
+    with pytest.raises(ValueError):
+        options.get_profile('does-not-exist', cfg=cfg)
+
+
+def test_circular_inheritance_raises():
+    cfg = make_config()
+    with pytest.raises(ValueError):
+        options.get_profile('cycle-a', cfg=cfg)
+
+
+def test_list_profiles():
+    cfg = make_config()
+    profiles = set(options.list_profiles(cfg=cfg))
+    assert {'lab', 'lab-scratch', 'lab-scratch-ro', 'drive'} <= profiles
+    # base sections are not profiles
+    assert 'login' not in profiles
+    assert 'basic' not in profiles
+
+
+class _StubInterface:
+    """Records the arguments ``get_interface`` passes to ``DefaultInterface``."""
+
+    def __init__(self, bucket_name, access_key, secret_key, endpoint_url,
+                 force_bucket_creation, verbose=True, backend='s3', **kwargs):
+        self.bucket_name = bucket_name
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.endpoint_url = endpoint_url
+        self.force_bucket_creation = force_bucket_creation
+        self.backend = backend
+        self.kwargs = kwargs
+
+
+def test_get_interface_uses_profile(monkeypatch):
+    cfg = make_config()
+    monkeypatch.setattr(options, 'config', cfg)
+    monkeypatch.setattr(cottoncandy.interfaces, 'DefaultInterface',
+                        _StubInterface)
+    cci = cc.get_interface(profile='lab')
+    assert cci.bucket_name == 'lab-shared'
+    assert cci.access_key == 'LABACCESS'
+    assert cci.secret_key == 'LABSECRET'
+    assert cci.endpoint_url == 'https://s3.example.edu/'
+    assert cci.backend == 's3'
+
+
+def test_get_interface_explicit_arg_overrides_profile(monkeypatch):
+    cfg = make_config()
+    monkeypatch.setattr(options, 'config', cfg)
+    monkeypatch.setattr(cottoncandy.interfaces, 'DefaultInterface',
+                        _StubInterface)
+    cci = cc.get_interface(bucket_name='override-bucket', profile='lab')
+    assert cci.bucket_name == 'override-bucket'
+    # the remaining settings still come from the profile
+    assert cci.access_key == 'LABACCESS'
+    assert cci.endpoint_url == 'https://s3.example.edu/'


### PR DESCRIPTION
## Summary

Add in multiple profiles in the config fig to specify different connections, and allows user to instantiate client objects based on the saved profile. The changes are backwards-compatible with existing config files.

```python
cloud = cottoncandy.get_interface(profile='mylab')
```

A profile is a single `[profile:NAME]` section in the config file that can have any of the following entries:

- `access_key`
- `secret_key`
- `endpoint_url`
- `default_bucket`
- `signature_version`
- `force_bucket_creation`
- `backend`
- and (for `backend = gdrive`) `secrets`/`credentials`. 
 
Anything a profile omits falls back to the base `[login]`/`[basic]`/`[gdrive]` sections, so this maintins compatibility with existing configs.

Profiles can **inherit** from another with the entry `inherits`; a child only specifies the keys it overrides:

```ini
[profile:mylab]
access_key = LABACCESSKEY
secret_key = LABSECRETKEY
endpoint_url = https://s3.example.edu/
default_bucket = lab-shared

[profile:mylab-scratch]
inherits = mylab
default_bucket = lab-scratch
```

`lab-scratch` will then use the same access key, secret key, and endpoint as `mylab`

## Resolution / precedence for when configs are available at multiple places
In order of decreasing precedence:
1. profile section entries
2. profile parent entries (if any)
3. default base section entries
4. environment variables or other disk config files

## Changes

- **`cottoncandy/options.py`**: add logic to read profiles from config file
- **`cottoncandy/__init__.py`**: `get_interface()` / `get_browser()` adds new argument `profile=` to allow user to specify config at instantiation
- **`cottoncandy/defaults.cfg`**: adds in profiles
- **`cottoncandy/tests/test_options.py`**: add unit tests
- **`README.md`**:  new "Profiles" section.

## Testing
tests all pass

https://claude.ai/code/session_01UEkty8EbGpn3mWcwtcSwdw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEkty8EbGpn3mWcwtcSwdw)_